### PR TITLE
Add css style to add line numbers

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -771,3 +771,23 @@ nav.pagination-nav {
 .theme-doc-sidebar-item-link-level-2 {
   --ifm-font-weight-semibold: 400;
 }
+
+/* ------------------------------------------- */
+/* Code Block line numbers */
+/* Example from: https://gist.github.com/uditalias/3969a20ef759bf3a8757499429b30063 */
+/* ------------------------------------------- */
+.theme-code-block {
+  counter-reset: line-number;
+}
+.theme-code-block .language-jsx .token-line::before,
+.theme-code-block .language-js .token-line::before {
+  counter-increment: line-number;
+  content: counter(line-number);
+  margin-right: calc(var(--ifm-pre-padding) * 1.5);
+  text-align: right;
+  min-width: 2.5rem;
+  display: inline-block;
+  opacity: 0.3;
+  position: sticky;
+  left: var(--ifm-pre-padding);
+}


### PR DESCRIPTION
Just a quick css addition to add line numbers for `jsx` and `js` codeblocks.  
Styles for other languages can be opted in as needed. 

![image](https://user-images.githubusercontent.com/5800058/166393992-3603b98e-857f-4564-b0af-c33287009a1e.png)
